### PR TITLE
feat(map): check Mapbox token

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,7 @@
+export function getMapboxToken(): string {
+  const token = process.env.MAPBOX_TOKEN;
+  if (!token) {
+    throw new Error('MAPBOX_TOKEN is not defined');
+  }
+  return token;
+}

--- a/backend/src/modules/map/map.service.ts
+++ b/backend/src/modules/map/map.service.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import { z } from 'zod';
+import { getMapboxToken } from '../../config/env';
 
 const MAPBOX_API_BASE_URL = 'https://api.mapbox.com';
-const MAPBOX_TOKEN = process.env.MAPBOX_TOKEN;
 
 const directionsSchema = z.object({
   origin: z.object({
@@ -23,11 +23,12 @@ export const mapService = {
   async getDirections(data: unknown) {
     const { origin, destination } = directionsSchema.parse(data);
     const url = `${MAPBOX_API_BASE_URL}/directions/v5/mapbox/driving/${origin.lng},${origin.lat};${destination.lng},${destination.lat}`;
+    const token = getMapboxToken();
 
     const response = await axios.get(url, {
       params: {
         geometries: 'geojson',
-        access_token: MAPBOX_TOKEN,
+        access_token: token,
       },
     });
 
@@ -39,10 +40,11 @@ export const mapService = {
     const url = `${MAPBOX_API_BASE_URL}/geocoding/v5/mapbox.places/${encodeURIComponent(
       query
     )}.json`;
+    const token = getMapboxToken();
 
     const response = await axios.get(url, {
       params: {
-        access_token: MAPBOX_TOKEN,
+        access_token: token,
         autocomplete: true,
       },
     });


### PR DESCRIPTION
## Summary
- ensure Mapbox token exists before calling external API
- centralize Mapbox token lookup in config module

## Testing
- `npm run lint --prefix backend` *(fails: ESLint couldn't find an eslint.config.* file)*
- `MAPBOX_TOKEN=dummy npm test --prefix backend` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d9a8d0e483208f6a687e879a9a2b