### PR TITLE
feat: add user payload typing

### DIFF
--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -1,10 +1,16 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import { Role } from '@prisma/client';
+
+export interface UserPayload {
+  id: string;
+  role: Role;
+}
 
 declare global {
   namespace Express {
     interface Request {
-      user?: any;
+      user?: UserPayload;
     }
   }
 }
@@ -19,7 +25,7 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
   const token = authHeader.split(' ')[1];
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET as string);
+    const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as UserPayload;
     req.user = decoded;
     next();
   } catch (error) {

--- a/backend/src/modules/rides/rides.controller.ts
+++ b/backend/src/modules/rides/rides.controller.ts
@@ -5,7 +5,9 @@ import { io } from '../../server';
 export const ridesController = {
   async createRide(req: Request, res: Response) {
     try {
-      // @ts-ignore
+      if (!req.user) {
+        return res.status(401).json({ message: 'Unauthorized' });
+      }
       const ride = await ridesService.createRide({ ...req.body, passengerId: req.user.id });
       // Emit to all drivers
       io.of('/rides').emit('ride:requested', ride);
@@ -17,7 +19,9 @@ export const ridesController = {
 
   async acceptRide(req: Request, res: Response) {
     try {
-      // @ts-ignore
+      if (!req.user) {
+        return res.status(401).json({ message: 'Unauthorized' });
+      }
       const ride = await ridesService.acceptRide(req.params.id, { driverId: req.user.id });
       io.of('/rides').emit('ride:accepted', ride);
       res.status(200).json(ride);
@@ -47,7 +51,9 @@ export const ridesController = {
 
   async getMyRides(req: Request, res: Response) {
     try {
-      // @ts-ignore
+      if (!req.user) {
+        return res.status(401).json({ message: 'Unauthorized' });
+      }
       const rides = await ridesService.getMyRides(req.user.id, req.user.role);
       res.status(200).json(rides);
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- type jwt payload and request user with Prisma role
- handle typed user in ride controller

## Testing
- `npm run lint --prefix backend` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d9ad47ec83208f8f462b4e0aac53