### PR TITLE
fix(map): initialize map once and remove unused state

### DIFF
--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import mapboxgl from 'mapbox-gl';
 import { initMap } from '../lib/mapbox';
 
@@ -10,14 +10,14 @@ const Map = ({ driverLocations }: MapProps) => {
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<mapboxgl.Map | null>(null);
   const markers = useRef<{ [key: string]: mapboxgl.Marker }>({});
-  const [lng, setLng] = useState(-46.6333);
-  const [lat, setLat] = useState(-23.5505);
-  const [zoom, setZoom] = useState(12);
 
   useEffect(() => {
     if (map.current || !mapContainer.current) return; // initialize map only once
+    const lng = -46.6333;
+    const lat = -23.5505;
+    const zoom = 12;
     map.current = initMap(mapContainer.current.id, [lng, lat], zoom);
-  });
+  }, []);
 
   useEffect(() => {
     if (!map.current || !driverLocations) return;


### PR DESCRIPTION
## Summary
- initialize Map component only once with empty effect dependencies
- drop unused state hooks for coordinates

## Testing
- `npm run lint --prefix frontend` *(fails: Unexpected any in Login.tsx, Register.tsx, RideForm.tsx, DriverDashboard.tsx)*
- `npm test --prefix frontend` *(no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d9ac35e88320bd0c435f44350a35