### PR TITLE
fix: ensure Prisma enums compile and dotenv config

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,3 @@
-DATABASE_URL=postgresql://postgres:LVhWvNcLXzFZNrjhfmFjBoAAhCDQRwUV@metro.proxy.rlwy.net:12787/railway
-JWT_SECRET=trocar_por_um_segredo_seguro
-MAPBOX_TOKEN=pk.eyJ1Ijoic3VwcmVtb3dpbGwiLCJhIjoiY21keHUydHM2MDEzYjJqcHMyNjlkbWVvbyJ9.FTzTaKQvyAZ3ihSNyAYFGg
+DATABASE_URL="postgresql://USER:PASS@HOST:PORT/DB?schema=public"
+JWT_SECRET="change-me"
 PORT=3001

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,10 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@prisma/client": "^6.13.0",
+        "@prisma/client": "6.13.0",
         "axios": "^1.11.0",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
+        "dotenv": "16.4.5",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "socket.io": "^4.8.1",
@@ -26,10 +27,10 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.2.1",
         "jest": "^29.7.0",
-        "prisma": "^6.13.0",
+        "prisma": "6.13.0",
         "ts-jest": "^29.2.5",
-        "ts-node-dev": "^2.0.0",
-        "typescript": "^5.9.2"
+        "ts-node-dev": "2.0.0",
+        "typescript": "5.9.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1921,6 +1922,19 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/c12/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/c12/node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -2397,10 +2411,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "devOptional": true,
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "test": "jest",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
+    "prisma:validate": "prisma validate",
     "prisma:studio": "prisma studio"
   },
   "keywords": [],
@@ -17,10 +18,11 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@prisma/client": "^6.13.0",
+    "@prisma/client": "6.13.0",
     "axios": "^1.11.0",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
+    "dotenv": "16.4.5",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "socket.io": "^4.8.1",
@@ -32,9 +34,9 @@
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.2.1",
-    "prisma": "^6.13.0",
-    "ts-node-dev": "^2.0.0",
-    "typescript": "^5.9.2",
+    "prisma": "6.13.0",
+    "ts-node-dev": "2.0.0",
+    "typescript": "5.9.2",
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -26,7 +26,7 @@ model User {
   email     String   @unique
   phone     String?
   password  String
-  role      Role
+  role      Role    @default(PASSENGER)
   carModel  String?  // para DRIVER
   carPlate  String?  // para DRIVER
   cnh       String?  // para DRIVER

--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -1,10 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import { Role } from '@prisma/client';
+import { $Enums } from '@prisma/client';
 
 export interface UserPayload {
   id: string;
-  role: Role;
+  role: $Enums.Role;
 }
 
 declare global {

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Role } from '@prisma/client';
+import { PrismaClient, $Enums } from '@prisma/client';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { z } from 'zod';
@@ -9,7 +9,7 @@ const registerSchema = z.object({
   name: z.string().min(3),
   email: z.string().email(),
   password: z.string().min(6),
-  role: z.nativeEnum(Role),
+  role: z.nativeEnum($Enums.Role),
   phone: z.string().optional(),
   carModel: z.string().optional(),
   carPlate: z.string().optional(),

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,6 +1,11 @@
+import 'dotenv/config';
 import http from 'http';
 import { Server } from 'socket.io';
 import app from './app';
+
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL not set. Create backend/.env (copy from .env.example).');
+}
 
 const port = process.env.PORT || 3001;
 


### PR DESCRIPTION
## Summary
- load environment variables early and ensure `DATABASE_URL` is defined
- adjust Prisma Role usage to `$Enums.Role` and set default role in schema
- pin Prisma packages to 6.13.0 and add dotenv plus validation script

## Testing
- `DATABASE_URL="postgresql://USER:PASS@HOST:PORT/DB?schema=public" npx prisma validate`
- `DATABASE_URL="postgresql://USER:PASS@HOST:PORT/DB?schema=public" npx prisma generate`
- `DATABASE_URL="postgresql://USER:PASS@HOST:PORT/DB?schema=public" JWT_SECRET="secret" PORT=4000 npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689890c15b388320b5a530a17cfafc2d